### PR TITLE
Corrected SQLUtils using improper date string format. The format tech…

### DIFF
--- a/spec/SQLUtils.spec.ts
+++ b/spec/SQLUtils.spec.ts
@@ -5,42 +5,42 @@ describe('SQLUtils', () => {
     describe('SQLUtils.toDatetime', () => {
         it('SQLUtils.toDatetime', () => {
             let date = new Date('2020-07-16T17:30:53.824Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16 17:30:53.824');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16T17:30:53.824Z');
         });
         
         it('< 100 ms date', () => {
             let date = new Date('2020-07-16T17:30:53.024Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16 17:30:53.024');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16T17:30:53.024Z');
         });
     
         it('< 10 ms date', () => {
             let date = new Date('2020-07-16T17:30:53.004Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16 17:30:53.004');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16T17:30:53.004Z');
         });
     
         it('Leading 0s for months', () => {
             let date = new Date('2020-07-16T17:30:53.004Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16 17:30:53.004');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-16T17:30:53.004Z');
         });
     
         it('Leading 0s for days', () => {
             let date = new Date('2020-07-06T17:30:53.004Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06 17:30:53.004');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06T17:30:53.004Z');
         });
     
         it('Leading 0s for hours', () => {
             let date = new Date('2020-07-06T07:30:53.004Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06 07:30:53.004');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06T07:30:53.004Z');
         });
     
         it('Leading 0s for minutes', () => {
             let date = new Date('2020-07-06T17:03:53.004Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06 17:03:53.004');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06T17:03:53.004Z');
         });
     
         it('Leading 0s for seconds', () => {
             let date = new Date('2020-07-06T17:30:03.004Z');
-            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06 17:30:03.004');
+            expect(SQLUtils.toDatetime(date)).toBe('2020-07-06T17:30:03.004Z');
         });
     });
     
@@ -117,7 +117,7 @@ describe('SQLUtils', () => {
         });
 
         it('Date', () => {
-            expect(SQLUtils.toValue(new Date(0))).toBe('"1970-01-01 00:00:00.000"');
+            expect(SQLUtils.toValue(new Date(0))).toBe('"1970-01-01T00:00:00.000Z"');
         });
     });
 });

--- a/src/SQLUtils.ts
+++ b/src/SQLUtils.ts
@@ -1,5 +1,8 @@
 import { SQLBoolean } from './SQLBoolean';
 
+/**
+ * Utility functions that are safe for both SQLite and MySQL.
+ */
 export class SQLUtils {
     private constructor() {}
 
@@ -49,39 +52,17 @@ export class SQLUtils {
         return out;
     }
 
+    /**
+     * 
+     * @param date 
+     * @returns Converts date to string. Currently uses ISO Strings. 
+     */
     public static toDatetime(date: Date): string {
         if (!(date instanceof Date)) {
             date = new Date(date);
         }
 
-        let month = date.getMonth() + 1;
-        let monthString: string = month < 10 ? `0${month}` : month.toString();
-
-        let day = date.getDate();
-        let dayString: string = day < 10 ? `0${day}` : day.toString();
-
-        let hour = date.getHours();
-        let hourString: string = hour < 10 ? `0${hour}` : hour.toString();
-
-        let minute = date.getMinutes();
-        let minuteString: string = minute < 10 ? `0${minute}` : minute.toString();
-
-        let second = date.getSeconds();
-        let secondString: string = second < 10 ? `0${second}` : second.toString();
-
-        let ms: number = date.getMilliseconds();
-        let msString: string = null;
-        if (ms < 10) {
-            msString = `00${ms}`;
-        }
-        else if (ms < 100) {
-            msString = `0${ms}`;
-        }
-        else {
-            msString = ms.toString();
-        }
-        
-        return `${date.getFullYear()}-${monthString}-${dayString} ${hourString}:${minuteString}:${secondString}.${msString}`;
+        return date.toISOString();
     }
 
     /**


### PR DESCRIPTION
…nically works but doesn't retain timezone information, which can cause problems if the environment is not UTC. Code now uses ISO String format (Date.toISOString).

Added jsdocs to SQLUtils and toDatetime. SQLUtils is now documented as a MySQL utility class.